### PR TITLE
Porting the cms sample function from cli-lib

### DIFF
--- a/functions/sample-function.js
+++ b/functions/sample-function.js
@@ -1,0 +1,29 @@
+// Require axios library to make API requests
+const axios = require("axios");
+
+// This function is executed when a request is made to the endpoint associated with this file in the serverless.json file
+exports.main = ({ accountId }, sendResponse) => {
+  // Use axios to make a GET request to the search API
+  axios
+    .get("https://api.hubapi.com/contentsearch/v2/search", {
+      params: {
+        portalId: accountId,
+        term: "searchTerm",
+      },
+    })
+    .then(function (response) {
+      // Handle success
+      // The console.log statement will appear in the terminal when you run the hs logs CLI command
+      // For full documentation, see: developers.hubspot.com/docs/cms/developer-reference/local-development-cms-cli#logs
+      console.log("Data received from the search API:", response.data);
+      // sendResponse is what you will send back to services hitting your serverless function
+      sendResponse({ body: { response: response.data }, statusCode: 200 });
+    })
+    .catch(function (error) {
+      // Handle error
+
+      // This is a simple example; error handling typically will be more complicated.
+      // For more information on error handling with axios, see: https://github.com/axios/axios#handling-errors
+      sendResponse({ body: { error: error.message }, statusCode: 500 });
+    });
+};


### PR DESCRIPTION
This is the code for the function that gets generated when users run the `hs create function` command. Currently it's hard-coded in [cli-lib here](https://github.com/HubSpot/cli-lib/blob/main/functions.js#L9). I have a [WIP PR in local-dev-lib](https://github.com/HubSpot/hubspot-local-dev-lib/pull/37) where I'm porting the functions.js top level export into the new library, and I figured this would be a good time to fix the pattern and make things more consistent. It should be easier to maintain the code that gets generated for the function if it lives in this repo vs. it being hard-coded in the cli-lib, which would require an npm publish for any changes to go live.

This is where I'm downloading the code in my latest PR: https://github.com/HubSpot/hubspot-local-dev-lib/pull/37/files#diff-1a4f65bce47ac7af164dc32ad60a6b49b7683b3437a000f5dc40c9066b11913aR190

@TanyaScales @jsines let me know what you think about this. I'm happy to put it somewhere else if you don't think it makes sense here.